### PR TITLE
fix Encoding::UndefinedConversionError when for config:set

### DIFF
--- a/lib/donjon/encrypted_file.rb
+++ b/lib/donjon/encrypted_file.rb
@@ -59,7 +59,7 @@ module Donjon
     end
 
     def _encrypt_for(user, data)
-      payload = data + OpenSSL::Random.random_bytes(PADDING)
+      payload = data + OpenSSL::Random.random_bytes(PADDING).force_encoding("UTF-8")
       password = OpenSSL::Random.random_bytes(32)
       encrypted_data = Gibberish::AES.new(password).encrypt(payload, binary: true)
       


### PR DESCRIPTION
I was unable to config:set UTF-8 character:

```
15:22:34 + crabman:(master)~/code/donjon >bundle exec ./bin/dj config:set msg="(╯°□°）╯︵ ┻━┻"
Please enter the password for your private key (/home/kim/.ssh/donjon_rsa)
> ************
/home/kim/code/donjon/lib/donjon/encrypted_file.rb:62:in `encode': "\xEA" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
    from /home/kim/code/donjon/lib/donjon/encrypted_file.rb:62:in `_encrypt_for'
    from /home/kim/code/donjon/lib/donjon/encrypted_file.rb:36:in `block in write'
    from /home/kim/code/donjon/lib/donjon/user.rb:51:in `call'
    from /home/kim/code/donjon/lib/donjon/user.rb:51:in `block in each'
    from /home/kim/code/donjon/lib/donjon/user.rb:47:in `each'
    from /home/kim/code/donjon/lib/donjon/user.rb:47:in `each'
    from /home/kim/code/donjon/lib/donjon/encrypted_file.rb:35:in `write'
    from /home/kim/code/donjon/lib/donjon/database.rb:19:in `[]='
    from /home/kim/code/donjon/lib/donjon/commands/config.rb:22:in `block in config_set'
    from /home/kim/code/donjon/lib/donjon/commands/config.rb:18:in `each'
    from /home/kim/code/donjon/lib/donjon/commands/config.rb:18:in `config_set'
    from /home/kim/code/donjon/lib/donjon/commands/base.rb:18:in `block in decl'
    from /home/kim/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /home/kim/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /home/kim/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /home/kim/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /home/kim/code/donjon/lib/donjon/commands/base.rb:14:in `start'
    from ./bin/dj:5:in `<main>'
```

**I'm not sure if this influences the quality of the random_bytes.** I can't find any documentation for `OpenSSL:Random.random_bytes` to find another way to fix this.
