### PR TITLE
Compatible with gibberish 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
 - 2.1.2
+- 2.2.2
 script:
 - bundle exec rspec

--- a/donjon.gemspec
+++ b/donjon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'thor'
-  spec.add_dependency 'gibberish'
+  spec.add_dependency 'gibberish', '>= 2.0.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/donjon/encrypted_file.rb
+++ b/lib/donjon/encrypted_file.rb
@@ -60,7 +60,7 @@ module Donjon
       decrypted_pw = user.key.private_decrypt(encrypted_key)
 
       assert(decrypted_pw.size == 32)
-      payload = Gibberish::AES.new(decrypted_pw).decrypt(encrypted_data, binary: true)
+      payload = Gibberish::AES::CBC.new(decrypted_pw).decrypt(encrypted_data, binary: true)
       encoding = payload[0...32].strip
       payload[32...-PADDING].force_encoding(encoding)
     end
@@ -72,8 +72,8 @@ module Donjon
       encoding_field = ("%-32s" % encoding).force_encoding(Encoding::BINARY)
       payload = encoding_field + data + OpenSSL::Random.random_bytes(PADDING)
       password = OpenSSL::Random.random_bytes(32)
-      encrypted_data = Gibberish::AES.new(password).encrypt(payload, binary: true)
-      
+      encrypted_data = Gibberish::AES::CBC.new(password).encrypt(payload, binary: true)
+
       encrypted_key = user.key.public_encrypt(password)
 
       assert(encrypted_key.size == 256)


### PR DESCRIPTION
Gibberish 2.0.0 introduces a breaking change in the API which breaks managing secrets with Donjon.

:wrench: Fixes binary data encryption/decryption 
:vertical_traffic_light: Check if `donjon` is compatible with the latest Ruby version

```
~ $ dj config:mget foo
Please enter the password for your private key (/Users/tadej/.ssh/donjon_rsa)
> **************
/usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/gibberish-2.0.0/lib/gibberish/aes.rb:106:in `decrypt': wrong number of arguments (2 for 1) (ArgumentError)
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/encrypted_file.rb:63:in `_decrypt_from'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/encrypted_file.rb:26:in `read'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/database.rb:35:in `block in each'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/database.rb:31:in `each'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/database.rb:31:in `each'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/commands/config.rb:58:in `config_mget'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/commands/base.rb:18:in `block in decl'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/lib/donjon/commands/base.rb:14:in `start'
        from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/donjon-2.0.0/bin/dj:5:in `<top (required)>'
        from /usr/local/var/rbenv/versions/2.1.2/bin/dj:23:in `load'
        from /usr/local/var/rbenv/versions/2.1.2/bin/dj:23:in `<main>'
```